### PR TITLE
fix: allow zero values in OpenAI config

### DIFF
--- a/src/ai/openaiService.ts
+++ b/src/ai/openaiService.ts
@@ -226,9 +226,9 @@ Ghi nhớ: Phản hồi của bạn sẽ giúp xây dựng hồ sơ của ngư�
     maxTokens?: number;
     temperature?: number;
   }) {
-    if (config.model) this.model = config.model;
-    if (config.maxTokens) this.maxTokens = config.maxTokens;
-    if (config.temperature) this.temperature = config.temperature;
+    if (config.model !== undefined) this.model = config.model;
+    if (config.maxTokens !== undefined) this.maxTokens = config.maxTokens;
+    if (config.temperature !== undefined) this.temperature = config.temperature;
 
     Logger.info("🔧 OpenAI configuration updated:", this.getModelInfo());
   }


### PR DESCRIPTION
## Summary
- allow zero and empty string overrides in updateConfig

## Testing
- `pnpm test`
- `pnpm type-check` *(fails: Object is possibly 'undefined' in database/operations.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68959b37f728832ca3d75cc411c413ca