### PR TITLE
feat: add server context and detailed user data

### DIFF
--- a/src/commands/crudTest.ts
+++ b/src/commands/crudTest.ts
@@ -73,17 +73,17 @@ export async function execute(
     }
 
     // Split long messages if needed
-    if (result.length > 2000) {
-      const chunks = result.match(/.{1,2000}/g) || [result];
-      await interaction.editReply(chunks[0]);
-      for (let i = 1; i < chunks.length; i++) {
-        if (chunks[i]) {
-          await interaction.followUp(chunks[i]);
+      if (result.length > 2000) {
+        const chunks = result.match(/.{1,2000}/g) || [result];
+        await interaction.editReply(chunks[0]);
+        for (let i = 1; i < chunks.length; i++) {
+          if (chunks[i]) {
+            await interaction.followUp(chunks[i]!);
+          }
         }
+      } else {
+        await interaction.editReply(result);
       }
-    } else {
-      await interaction.editReply(result);
-    }
   } catch (error) {
     Logger.error("❌ CRUD test command failed:", error);
     const errorMsg = error instanceof Error ? error.message : "Unknown error";
@@ -113,6 +113,10 @@ async function testUserProfile(
       preferredResponseStyle: "technical",
       timezone: "UTC",
       language: "en",
+      bio: "Test bio",
+      goals: "Learn testing",
+      preferences: "TypeScript",
+      notes: "General notes",
     };
 
     // Test CREATE
@@ -133,6 +137,10 @@ async function testUserProfile(
       results.push(`   Interests: ${retrieved.interests.join(", ")}`);
       results.push(`   Personality: ${retrieved.personality.join(", ")}`);
       results.push(`   Recent Topics: ${retrieved.recentTopics.join(", ")}`);
+      if (retrieved.bio) results.push(`   Bio: ${retrieved.bio}`);
+      if (retrieved.goals) results.push(`   Goals: ${retrieved.goals}`);
+      if (retrieved.preferences) results.push(`   Preferences: ${retrieved.preferences}`);
+      if (retrieved.notes) results.push(`   Notes: ${retrieved.notes}`);
     } else {
       results.push("❌ Failed to retrieve user profile");
     }

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -7,6 +7,7 @@ import { AIManager } from "../ai/aiManager.js";
 import { TTSManager } from "../tts/ttsManager.js";
 import { VoiceManager } from "../utils/voiceManager.js";
 import { DatabaseManager } from "../database/databaseManager.js";
+import { DatabaseCRUD } from "../database/operations.js";
 
 // Global instances (will be set by main bot)
 let channelManager: ChannelManager;
@@ -74,6 +75,20 @@ export default {
       channelInfo
     );
     messageProcessor.logMessage(processedMessage);
+
+    // Record server event
+    if (databaseManager?.isReady() && message.guild) {
+      try {
+        const crud = new DatabaseCRUD(databaseManager.getDatabase());
+        await crud.addServerRecentEvent(
+          message.guild.id,
+          "message",
+          message.author.id
+        );
+      } catch (err) {
+        Logger.debug("Failed to log server event", err);
+      }
+    }
 
     // Handle commands
     if (processedMessage.messageType === "command" && commandHandler) {

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,6 +1,7 @@
 import { Client, Events } from "discord.js";
 import { Logger } from "../utils/logger.js";
 import { ChannelManager } from "../utils/channelManager.js";
+import { DatabaseCRUD } from "../database/operations.js";
 
 export default {
   name: Events.ClientReady,
@@ -40,6 +41,19 @@ export default {
             Logger.info(
               `📊 Database: ${dbStats.sizeMB}MB, ${dbStats.tables} tables, ${dbStats.journalMode} mode`
             );
+          }
+
+          // Create server profiles for connected guilds
+          const crud = new DatabaseCRUD(databaseManager.getDatabase());
+          for (const guild of client.guilds.cache.values()) {
+            await crud.createServerProfile({
+              serverId: guild.id,
+              serverName: guild.name,
+              ownerId: guild.ownerId,
+              memberCount: guild.memberCount,
+              recentEvents: [],
+              lastActivity: Math.floor(Date.now() / 1000),
+            });
           }
         } else {
           Logger.error("❌ Database Manager initialization failed");


### PR DESCRIPTION
## Summary
- track per-server context and recent events for multi-server adaptation
- extend user profiles with bio, goals, preferences and general notes
- log server activity on message receipt and initialize server profiles on startup

## Testing
- `npm test`
- `npm run type-check` *(fails: Parameter 'db' implicitly has an 'any' type, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6895a0374020832c8c842cc2529474b2