### PR TITLE
refactor: replace raw SQL with Prisma ORM operations

### DIFF
--- a/src/database/databaseManager.ts
+++ b/src/database/databaseManager.ts
@@ -61,12 +61,13 @@ export class DatabaseManager {
 
   async getStats(): Promise<any> {
     if (!this.prisma) return null;
-    const result: any = await this.prisma.$queryRaw`SELECT
-         (SELECT COUNT(*) FROM user_profiles) AS users,
-         (SELECT COUNT(*) FROM channel_contexts) AS channels,
-         (SELECT COUNT(*) FROM server_profiles) AS servers,
-         (SELECT COUNT(*) FROM conversation_history) AS messages`;
-    return result[0];
+    const [users, channels, servers, messages] = await Promise.all([
+      this.prisma.userProfile.count(),
+      this.prisma.channelContext.count(),
+      this.prisma.serverProfile.count(),
+      this.prisma.conversationHistory.count(),
+    ]);
+    return { users, channels, servers, messages };
   }
 
   async cleanup(): Promise<void> {
@@ -82,7 +83,7 @@ export class DatabaseManager {
     try {
       checks.connected = !!this.prisma;
       if (this.prisma) {
-        await this.prisma.$queryRaw`SELECT 1`;
+        await this.prisma.userProfile.count();
         checks.queryable = true;
       } else {
         checks.queryable = false;


### PR DESCRIPTION
## Summary
- replace raw SQL queries with Prisma ORM upserts and find operations across database CRUD
- calculate stats and health checks via Prisma counts

## Testing
- `pnpm test`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_68961b11f98c832c92f95eee1710bcfe